### PR TITLE
Set error flag in bError of RDR_to_PC_SlotStatus

### DIFF
--- a/Class/CCID/Src/usbd_ccid_cmd.c
+++ b/Class/CCID/Src/usbd_ccid_cmd.c
@@ -792,7 +792,7 @@ void RDR_to_PC_SlotStatus(uint8_t  errorCode, USBD_HandleTypeDef *pdev)
 
   hccid->UsbBlkInData.bMessageType = RDR_TO_PC_SLOTSTATUS;
   hccid->UsbBlkInData.dwLength = 0U;
-  hccid->UsbBlkInData.bError = 0U;
+  hccid->UsbBlkInData.bError = errorCode;
   hccid->UsbBlkInData.bSpecific = 0U;    /* bClockStatus = 00h Clock running
   01h Clock stopped in state L
   02h Clock stopped in state H


### PR DESCRIPTION
This PR fixes the fact that `RDR_to_PC_SlotStatus` does not apply the given `errorCode` in the `bError` field.

The error was then always interpreted as if the command is unsupported.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32_mw_usb_device/blob/master/CONTRIBUTING.md) file.
