### PR TITLE
Fix: Set default value of USBD_MAX_STR_DESC_SIZ in usbd_conf_template.h to 255

### DIFF
--- a/Core/Inc/usbd_conf_template.h
+++ b/Core/Inc/usbd_conf_template.h
@@ -45,7 +45,7 @@ extern "C" {
 
 #define USBD_MAX_NUM_INTERFACES                     1U
 #define USBD_MAX_NUM_CONFIGURATION                  1U
-#define USBD_MAX_STR_DESC_SIZ                       0x100U
+#define USBD_MAX_STR_DESC_SIZ                       0xFFU /* Descriptor 'bLength' max value */
 #define USBD_SELF_POWERED                           1U
 #define USBD_DEBUG_LEVEL                            2U
 /* #define USBD_USER_REGISTER_CALLBACK                 1U */


### PR DESCRIPTION
Currently, `usbed_conf_template.h` defines `USBD_MAX_STR_DESC_SIZ` to `0x100` (256) by default. However, the maximum length of a string descriptor is `0xFF`  (i.e., max value of `bLength` field is 255).

Thus, if users forget to update this default value of `USBD_MAX_STR_DESC_SIZ`, and also mistakenly specify a C string > 127 bytes, this will result in:
    - `USBD_GetString()` -> `MIN()`  returning a length of `USBD_MAX_STR_DESC_SIZ` (which is `256`)
    - `USBD_GetString()` -> `unicode[idx] = *(uint8_t *)len;`  attempts to assign `256`. But the `uint8_t` type causes it to be cast to `0`, thus the `bLength` field is set to `0`

This PR updates `USBD_MAX_STR_DESC_SIZ` to `255` such that even if users mistakenly specify a longer C string, the `MIN()` call will still round down to a valid length.
